### PR TITLE
[Feat/#6]: color, fontSize 정의, 댓글 바텀시트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     // var 금지
     "no-var": "warn",
     "import/prefer-default-export": 0,
+    "@typescript-eslint/no-explicit-any": "off",
     // jsx 파일 확장자 .jx, .jsx, .ts, .tsx 허용
     "react/jsx-filename-extension": [
       2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.2.67",
         "@types/react-dom": "^18.2.22",
         "@types/styled-components": "^5.1.34",
+        "framer-motion": "^11.0.20",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
@@ -8692,6 +8693,30 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.0.20",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.20.tgz",
+      "integrity": "sha512-YSDmWznt3hpdERosbE0UAPYWoYhTnmQ0J1qWPsgpCia9NgY8Xsz5IpOiUEGGj/nzCAW29fSrWugeLRkdp5de7g==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.2.67",
     "@types/react-dom": "^18.2.22",
     "@types/styled-components": "^5.1.34",
+    "framer-motion": "^11.0.20",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/src/assets/bottomSheet/Line.svg
+++ b/src/assets/bottomSheet/Line.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="4" viewBox="0 0 36 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Line 95" d="M2 2H34" stroke="#ACD1AD" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -26,6 +26,8 @@ const Container = styled.div`
   height: calc(var(--vh, 1vh) * 100);
   background-color: white;
   border-radius: 0px;
+  position: relative;
+  overflow: hidden;
 
   // 모바일 사이즈(최대 430px)에서 벗어날 경우 사이즈 고정
   @media screen and (min-width: 430px) {

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+/* ----- 모달 바깥 클릭 시 모달이 닫히도록 하는 hook -----
+
+- ref: 모달에 해당하는 ref 객체
+- handler: 바깥 클릭 시 실행할 함수
+
+  ** 예시 **
+  const ref = useRef<HTMLDivElement | null>(null);
+  useClickOutside(ref, () => setOpen(false));
+*/
+
+function useClickOutside(
+  ref: React.RefObject<HTMLElement>,
+  handler: () => void
+) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, handler]);
+}
+
+export default useClickOutside;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,16 @@
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
 import App from './App';
+import { theme } from './styles/theme';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <BrowserRouter>
-    <App />
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
   </BrowserRouter>
 );

--- a/src/pages/CommentBottomSheet.tsx
+++ b/src/pages/CommentBottomSheet.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { motion, useAnimation, useDragControls } from 'framer-motion';
+import Line from '../assets/bottomSheet/Line.svg';
+
+type CommentBottomSheetProps = {
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+function CommentBottomSheet({ setOpen }: CommentBottomSheetProps) {
+  const ref = useRef<HTMLDivElement | null>(null); // BottomSheet에 대한 red
+  const [initialY, setInitialY] = useState<number>(0); // BottomSheet 초기 y 위치
+  const [sheetHeight, setSheetHeight] = useState<number>(0); // BottomSheet 높이
+  const controls = useAnimation(); // BottomSheet 애니메이션 제어
+  const dragControls = useDragControls(); // drag 제어
+
+  /* ----- 마운트 시 초기 y 위치, botton sheet 높이 구하기 ----- */
+  useEffect(() => {
+    if (ref.current) {
+      setInitialY(ref.current.offsetTop);
+      setSheetHeight(ref.current.offsetHeight);
+    }
+  }, []);
+
+  /* ----- 바텀시트 종료 함수 (drag 속도 기반) ----- */
+  const handleDragEnd = (
+    event: MouseEvent | TouchEvent | PointerEvent,
+    info: any
+  ) => {
+    const velocity = info.velocity.y; // y축에 대한 드래그 속도
+    // 속도가 일정 값을 초과하면?
+    if (velocity > 500) {
+      controls.start({ y: sheetHeight + 1000 }); // BottomSheet를 애니메이션하여 화면 밖으로 내보냄
+      setTimeout(() => setOpen(false), 500); // BottomSheet를 완전히 닫음
+    }
+  };
+
+  return (
+    <Background>
+      <BottomSheet
+        ref={ref}
+        drag='y'
+        dragControls={dragControls}
+        dragListener={false}
+        dragConstraints={{
+          top: -initialY + 10, // 초기 y 위치 + 10만큼 위로 드래그 가능
+          bottom: sheetHeight * 0.3, // 시트 높이 * 0.3 만큼 아래로 드래그 가능
+        }}
+        dragElastic={0.1}
+        onDragStart={() => setInitialY(ref.current?.offsetTop || 0)} // 드래그 시작 시 초기 Y 위치 업데이트
+        onDragEnd={handleDragEnd} // 드래그 종료 이벤트 처리
+        animate={controls} // 애니메이션 적용
+        transition={{ duration: 0.5 }} // 애니메이션 지속 시간
+      >
+        <Header onPointerDown={(e) => dragControls.start(e)}>
+          <img src={Line} alt='line' />
+        </Header>
+      </BottomSheet>
+    </Background>
+  );
+}
+
+export default CommentBottomSheet;
+
+const Background = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: #80808076;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 100;
+`;
+
+const BottomSheet = styled(motion.div)`
+  width: 100%;
+  height: calc(100% + 20px);
+  background-color: ${({ theme }) => theme.colors.bg_white};
+  border-radius: 18px 18px 0 0;
+  padding-bottom: 20px;
+
+  position: absolute;
+  top: 20%;
+  left: 0;
+  z-index: 999;
+`;
+
+const Header = styled.button`
+  width: 100%;
+  padding: 10px 0px;
+`;

--- a/src/pages/CommentBottomSheet.tsx
+++ b/src/pages/CommentBottomSheet.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { motion, useAnimation, useDragControls } from 'framer-motion';
 import Line from '../assets/bottomSheet/Line.svg';
+import { fadeUp } from '../styles/GlobalStyles';
 
 type CommentBottomSheetProps = {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -84,6 +85,7 @@ const BottomSheet = styled(motion.div)`
   top: 20%;
   left: 0;
   z-index: 999;
+  animation: ${fadeUp} 1s;
 `;
 
 const Header = styled.button`

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import CommentBottomSheet from './CommentBottomSheet';
 
 function HomePage() {
-  return <Container>HomePage</Container>;
+  const [commentOpen, setCommentOpen] = useState<boolean>(false);
+
+  return (
+    <Container>
+      <button
+        type='button'
+        onClick={() => setCommentOpen(true)}
+        style={{ border: '1px solid gray' }}
+      >
+        댓글 바텀시트 테스트
+      </button>
+      {commentOpen && <CommentBottomSheet setOpen={setCommentOpen} />}
+    </Container>
+  );
 }
 
 export default HomePage;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, keyframes } from 'styled-components';
 import '../assets/font/font.css';
 import reset from 'styled-reset';
 
@@ -27,4 +27,9 @@ export const GlobalStyles = createGlobalStyle`
     align-items: center;
     background-color: #f1f1f1;
   }
+`;
+
+export const fadeUp = keyframes`
+  0% { transform: translateY(100%); }
+  100% { transform: translateY(0%); }
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,1 +1,28 @@
-export {};
+import { Colors, Font } from 'styled-components';
+
+const colors: Colors = {
+  key_color: '#ACD1AD',
+  key_color_light: '#DCE4DC',
+  bg_white: '#ffffff',
+  text_black: '#000',
+  text_lightgray: '#B1B1B1',
+  text_red: '#F00',
+  input_gray: '#D9D9D9',
+};
+
+const fontSize: Font = {
+  xxs: '6px',
+  xs: '8px',
+  sm: '10px',
+  base: '12px',
+  md: '14px',
+  lg: '16px',
+  xl: '18px',
+  xxl: '20px',
+  xxxl: '24px',
+};
+
+export const theme = {
+  colors,
+  fontSize,
+};

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -1,0 +1,24 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface Colors {
+    key_color: string;
+    key_color_light: string;
+    bg_white: string;
+    text_black: string;
+    text_lightgray: string;
+    text_red: string;
+    input_gray: string;
+  }
+  export interface Font {
+    xxs: string;
+    xs: string;
+    sm: string;
+    base: string;
+    md: string;
+    lg: string;
+    xl: string;
+    xxl: string;
+    xxxl: string;
+  }
+}


### PR DESCRIPTION
## 📍 작업 내용
### ✔️ color, fontsize 정의

theme.ts에 스타일링에 활용할 속성들을 정의해놓았습니다.
현재까지 디자인에 반영된 color만 정의해두었고, fontSize는 임의로 설정해놓았습니다.
→ 추후 필요에 따라 지속적으로 업데이트하면 될 것 같아요

```tsx
import { Colors, Font } from 'styled-components';

const colors: Colors = {
  key_color: '#ACD1AD',
  key_color_light: '#DCE4DC',
  bg_white: '#ffffff',
  text_black: '#000',
  text_lightgray: '#B1B1B1',
  text_red: '#F00',
  input_gray: '#D9D9D9',
};

const fontSize: Font = {
  xxs: '6px',
  xs: '8px',
  sm: '10px',
  base: '12px',
  md: '14px',
  lg: '16px',
  xl: '18px',
  xxl: '20px',
  xxxl: '24px',
};

export const theme = {
  colors,
  fontSize,
};
```

새로운 속성을 추가하려면 우선 아래에 보이는 types/styled.d.ts 파일에 추가할 속성의 타입을 추가해주고, theme.ts에 해당 속성을 추가해주면 됩니다.

→ 일회성으로 사용하는 컬러는 정의할 필요 없습니다!

```tsx
import 'styled-components';

declare module 'styled-components' {
  export interface Colors {
    key_color: string;
    key_color_light: string;
    bg_white: string;
    text_black: string;
    text_lightgray: string;
    text_red: string;
    input_gray: string;
  }
  export interface Font {
    xxs: string;
    xs: string;
    sm: string;
    base: string;
    md: string;
    lg: string;
    xl: string;
    xxl: string;
    xxxl: string;
  }
}
```

속성을 가져와 사용하는 방법은 다음과 같음!

```css
color: ${({ theme }) => theme.colors.key_color};
```

```css
font-size: ${({ theme }) => theme.fontSize.base};
```

<br/>

### ✔️ 댓글 바텀시트 구현
위로 드래그 되고, 아래로 절반 정도만 드래그 되게 하였고 빠른 속도로 드래그 할 경우 바텀시트가 내려가면서 닫히게끔 구현했습니다. (모바일 테스트 완)


<br/>

## 📍 구현 결과
<img src='https://github.com/Team-Frolog/Frolog-front/assets/121474189/a0fdcc56-f6ff-4f2f-9681-d4b711311299' alt='img' width='500px' />

<br/>

## 📍 기타 사항
- 바텀시트 테스트용 버튼은 지금 홈화면에 있기 때문에 홈화면 작업할 때 버튼은 다른 곳으로 옮겨놓던지 하세욥

<br/>
